### PR TITLE
add simple test for broadcasting for samplers

### DIFF
--- a/tests/test_rhmc.py
+++ b/tests/test_rhmc.py
@@ -61,8 +61,8 @@ def test_leapfrog_reversibility(params):
 @pytest.mark.parametrize(
     "params",
     [
-        dict(sampler='RHMC'  , epsilon=0.2, n_steps=5, n_burn=1000, n_samples=5000),
-        dict(sampler='RSGLD' , epsilon=1e-3, n_burn=3000, n_samples=10000),
+        dict(sampler='RHMC', epsilon=0.2, n_steps=5, n_burn=1000, n_samples=5000),
+        dict(sampler='RSGLD', epsilon=1e-3, n_burn=3000, n_samples=10000),
         dict(sampler='SGRHMC', epsilon=1e-3, n_steps=1, alpha=0.5, n_burn=3000, n_samples=10000)
     ],
 )
@@ -87,7 +87,6 @@ def test_sampling(params):
     nd = NormalDist(mu, sigma)
     Sampler = getattr(geoopt.samplers, params.pop('sampler'))
     sampler = Sampler(nd.parameters(), **params)
-    #sampler = geoopt.samplers.RHMC(nd.parameters(), n_steps=5, epsilon=0.2)
 
     for _ in range(n_burn):
         sampler.step(nd)
@@ -102,6 +101,49 @@ def test_sampling(params):
     points = np.asarray(points)
     points = points[::20]
 
-    #assert points.shape == (n_samples, D)
     np.testing.assert_allclose(mu.numpy(), points.mean(axis=0), atol=1e-1)
     np.testing.assert_allclose(sigma.numpy(), points.std(axis=0), atol=1e-1)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        dict(sampler='RHMC', epsilon=0.2, n_steps=5, n_burn=10, n_samples=50, nd=()),
+        dict(sampler='RSGLD', epsilon=1e-3, n_burn=30, n_samples=100, nd=()),
+        dict(sampler='SGRHMC', epsilon=1e-3, n_steps=1, alpha=0.5, n_burn=30, n_samples=100, nd=(3, )),
+        dict(sampler='RHMC', epsilon=0.2, n_steps=5, n_burn=1000, n_samples=50, nd=(3, )),
+        dict(sampler='RSGLD', epsilon=1e-3, n_burn=30, n_samples=10000, nd=(3, )),
+        dict(sampler='SGRHMC', epsilon=1e-3, n_steps=1, alpha=0.5, n_burn=30, n_samples=100, nd=(3, ))
+    ],
+)
+def test_sampling_manifold(params):
+    # should just work (all business stuff is checked above)
+    class NormalDist(torch.nn.Module):
+        def __init__(self, mu, sigma):
+            super().__init__()
+            self.d = torch.distributions.Normal(mu, sigma)
+            self.x = geoopt.ManifoldParameter(torch.randn_like(mu), manifold=geoopt.Stiefel())
+
+        def forward(self):
+            return self.d.log_prob(self.x).sum()
+
+    torch.manual_seed(42)
+    D = (5, 4)
+    n_burn, n_samples = params.pop('n_burn'), params.pop('n_samples')
+    nd = params.pop('nd')  # type: tuple
+    mu = torch.randn(nd + D)
+    sigma = torch.randn(nd + D).abs()
+
+    nd = NormalDist(mu, sigma)
+    Sampler = getattr(geoopt.samplers, params.pop('sampler'))
+    sampler = Sampler(nd.parameters(), **params)
+
+    for _ in range(n_burn):
+        sampler.step(nd)
+
+    points = []
+    sampler.burnin = False
+
+    for _ in range(n_samples):
+        sampler.step(nd)
+        points.append(nd.x.detach().numpy().copy())


### PR DESCRIPTION
TODO: verify the following 
https://github.com/ferrine/geoopt/blob/master/geoopt/samplers/samplers.py#L240

There was an adaptive term when I was implementing adam, I had to broadcast this term ([here](https://github.com/ferrine/geoopt/blob/master/geoopt/optim/radam.py#L85)) for the tensor if I have for example 3x5x6 (3 points on stiefel manifold). Is there any corner case with broadcasting?