### PR TITLE
change internals to match future api

### DIFF
--- a/geoopt/optim/rsgd.py
+++ b/geoopt/optim/rsgd.py
@@ -51,73 +51,73 @@ class RiemannianSGD(OptimMixin, torch.optim.Optimizer):
         loss = None
         if closure is not None:
             loss = closure()
+        with torch.no_grad():
+            for group in self.param_groups:
+                if "step" not in group:
+                    group["step"] = 0
+                weight_decay = self.group_param_tensor(group, "weight_decay")
+                momentum = self.group_param_tensor(group, "momentum")
+                dampening = self.group_param_tensor(group, "dampening")
+                nesterov = group["nesterov"]
+                learning_rate = self.group_param_tensor(group, "lr")
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    state = self.state[p]
 
-        for group in self.param_groups:
-            if "step" not in group:
-                group["step"] = 0
-            weight_decay = self.group_param_tensor(group, "weight_decay")
-            momentum = self.group_param_tensor(group, "momentum")
-            dampening = self.group_param_tensor(group, "dampening")
-            nesterov = group["nesterov"]
-            learning_rate = self.group_param_tensor(group, "lr")
-            for p in group["params"]:
-                if p.grad is None:
-                    continue
-                state = self.state[p]
+                    # State initialization
+                    if len(state) == 0:
+                        if momentum != 0:
+                            state["momentum_buffer"] = p.grad.clone()
+                    if "traced_step" not in state:
+                        if isinstance(p, (ManifoldParameter, ManifoldTensor)):
+                            manifold = p.manifold
+                        else:
+                            manifold = Euclidean()
 
-                # State initialization
-                if len(state) == 0:
-                    if momentum != 0:
-                        state["momentum_buffer"] = p.grad.clone()
-                if "traced_step" not in state:
-                    if isinstance(p, (ManifoldParameter, ManifoldTensor)):
-                        manifold = p.manifold
-                    else:
-                        manifold = Euclidean()
-
+                        if group["use_momentum"]:
+                            state["traced_step"] = create_traced_update(
+                                self.perform_step,
+                                manifold,
+                                p,
+                                weight_decay.type_as(p),
+                                momentum.type_as(p),
+                                state["momentum_buffer"],
+                                dampening=dampening,
+                                nesterov=nesterov,
+                                use_momentum=group["use_momentum"],
+                            )
+                        else:
+                            state["traced_step"] = create_traced_update(
+                                self.perform_step,
+                                manifold,
+                                p,
+                                weight_decay.type_as(p),
+                                momentum=None,
+                                momentum_buffer=None,
+                                dampening=dampening,
+                                nesterov=nesterov,
+                                use_momentum=group["use_momentum"],
+                            )
                     if group["use_momentum"]:
-                        state["traced_step"] = create_traced_update(
-                            self.perform_step,
-                            manifold,
-                            p.data,
+                        state["traced_step"](
+                            p,
+                            p.grad,
+                            learning_rate.type_as(p),
                             weight_decay.type_as(p),
                             momentum.type_as(p),
                             state["momentum_buffer"],
-                            dampening=dampening,
-                            nesterov=nesterov,
-                            use_momentum=group["use_momentum"],
                         )
                     else:
-                        state["traced_step"] = create_traced_update(
-                            self.perform_step,
-                            manifold,
-                            p.data,
+                        state["traced_step"](
+                            p,
+                            p.grad,
+                            learning_rate.type_as(p),
                             weight_decay.type_as(p),
-                            momentum=None,
-                            momentum_buffer=None,
-                            dampening=dampening,
-                            nesterov=nesterov,
-                            use_momentum=group["use_momentum"],
                         )
-                if group["use_momentum"]:
-                    state["traced_step"](
-                        p.data,
-                        p.grad,
-                        learning_rate.type_as(p),
-                        weight_decay.type_as(p),
-                        momentum.type_as(p),
-                        state["momentum_buffer"],
-                    )
-                else:
-                    state["traced_step"](
-                        p.data,
-                        p.grad,
-                        learning_rate.type_as(p),
-                        weight_decay.type_as(p),
-                    )
-            group["step"] += 1
-            if self._stabilize is not None and group["step"] % self._stabilize == 0:
-                self.stabilize_group(group)
+                group["step"] += 1
+                if self._stabilize is not None and group["step"] % self._stabilize == 0:
+                    self.stabilize_group(group)
         return loss
 
     @staticmethod
@@ -152,17 +152,18 @@ class RiemannianSGD(OptimMixin, torch.optim.Optimizer):
             point.set_(new_point)
 
     def stabilize_group(self, group):
-        for p in group["params"]:
-            if not isinstance(p, (ManifoldParameter, ManifoldTensor)):
-                continue
-            manifold = p.manifold
-            momentum = group["momentum"]
-            p.data.set_(manifold.projx(p.data))
-            if momentum > 0:
-                param_state = self.state[p]
-                if "momentum_buffer" in param_state:
-                    buf = param_state["momentum_buffer"]
-                    buf.data.set_(manifold.proju(p.data, buf))
+        with torch.no_grad():
+            for p in group["params"]:
+                if not isinstance(p, (ManifoldParameter, ManifoldTensor)):
+                    continue
+                manifold = p.manifold
+                momentum = group["momentum"]
+                p.set_(manifold.projx(p))
+                if momentum > 0:
+                    param_state = self.state[p]
+                    if "momentum_buffer" in param_state:
+                        buf = param_state["momentum_buffer"]
+                        buf.set_(manifold.proju(p, buf))
 
     def _sanitize_group(self, group):
         group = group.copy()

--- a/geoopt/tensor.py
+++ b/geoopt/tensor.py
@@ -17,13 +17,15 @@ class ManifoldTensor(torch.Tensor):
             data = torch.Tensor.__new__(cls, *args, **kwargs)
         if kwargs.get("device") is not None:
             data.data = data.data.to(kwargs.get("device"))
-        manifold.assert_check_point(data.data)
+        with torch.no_grad():
+            manifold.assert_check_point(data)
         instance = torch.Tensor._make_subclass(cls, data, requires_grad)
         instance.manifold = manifold
         return instance
 
     def proj_(self):
-        self.data.set_(self.manifold.projx(self.data))
+        with torch.no_grad():
+            self.set_(self.manifold.projx(self.data))
         return self
 
     def retr(self, u, t):

--- a/tests/test_rhmc.py
+++ b/tests/test_rhmc.py
@@ -44,14 +44,16 @@ def test_leapfrog_reversibility(params):
     for i in range(n_steps):
         logp = nd()
         logp.backward()
-        sampler._step(nd.x, r, epsilon)
-        nd.x.grad.zero_()
+        with torch.no_grad():
+            sampler._step(nd.x, r, epsilon)
+            nd.x.grad.zero_()
 
     for i in range(n_steps):
         logp = nd()
         logp.backward()
-        sampler._step(nd.x, r, -epsilon)
-        nd.x.grad.zero_()
+        with torch.no_grad():
+            sampler._step(nd.x, r, -epsilon)
+            nd.x.grad.zero_()
 
     new_x = nd.x.data.numpy().copy()
     np.testing.assert_allclose(init_x, new_x, rtol=1e-5)


### PR DESCRIPTION
Adresses #21 

As it was mentioned in [discuss](https://discuss.pytorch.org/t/api-change-for-tensor-data-set-in-torch-nightly/33310/3) we need to use something like this instead
```
>>> y.data.set_(z) # ERROR!
>>> with torch.no_grad():
            y.set_(z) # OK
```
Thus in this PR, I've changed all usages of tensor.data into `torch.no_grad()`