### PR TITLE
make Manifold as Module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Maintenance
 -----------
 * Add gitter chat (#31)
 * Maintain torch>=1.0.0 only (#39)
+* Manifolds are Modules (#49)
 
 Deprecations
 ------------

--- a/geoopt/manifolds/base.py
+++ b/geoopt/manifolds/base.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import abc
-import torch
+import torch.nn
 import re
 
 __all__ = ["Manifold"]
@@ -148,7 +148,7 @@ def not_implemented(*args, **kwargs):
     raise NotImplementedError
 
 
-class Manifold(metaclass=ManifoldMeta):
+class Manifold(torch.nn.Module, metaclass=ManifoldMeta):
     r"""
     Base class for Manifolds
 
@@ -190,6 +190,13 @@ class Manifold(metaclass=ManifoldMeta):
     ndim = None
     reversible = None
     _default_order = 1
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    def forward(self, *input):
+        # this removes all warnings about implementing abstract methods
+        raise TypeError("Manifold is not callable")
 
     # noinspection PyAttributeOutsideInit
     def set_default_order(self, order):

--- a/geoopt/manifolds/sphere.py
+++ b/geoopt/manifolds/sphere.py
@@ -116,6 +116,7 @@ class SphereSubspaceIntersection(Sphere):
     name = "SphereSubspace"
 
     def __init__(self, span):
+        super().__init__()
         self._configure_manifold(span)
         if (geoopt.linalg.batch_linalg.matrix_rank(self._projector) == 1).any():
             raise ValueError(


### PR DESCRIPTION
address #49

The only change is adding a base class to a Manifold, that implements all the stuff we need. To avoid type checker warnings, `forward` method explicitly raises a TypeError as we are never supposed to use this.
